### PR TITLE
Compatibility with Rust 2021

### DIFF
--- a/examples/highlevel.rs
+++ b/examples/highlevel.rs
@@ -5,7 +5,7 @@ mod png;
 use exoquant::*;
 use std::env;
 
-// usage: cargo run --release --demo highlevel <in.png> <out.png> <num_colors>
+// usage: cargo run --release --example highlevel <in.png> <out.png> <num_colors>
 fn main() {
     let mut args = env::args();
     args.next();

--- a/examples/lowlevel.rs
+++ b/examples/lowlevel.rs
@@ -6,7 +6,7 @@ use std::env;
 use exoquant::*;
 use exoquant::optimizer::Optimizer;
 
-// usage: cargo run --release --demo lowlevel <in.png> <out.png> <num_colors>
+// usage: cargo run --release --example lowlevel <in.png> <out.png> <num_colors>
 fn main() {
     let mut args = env::args();
     args.next();

--- a/src/ditherer.rs
+++ b/src/ditherer.rs
@@ -10,11 +10,11 @@ pub trait Ditherer {
     /// Remaps an iterator of input pixel (float-)colors of an Image to an Iterator of palette
     /// indices.
     fn remap<'a>(&'a self,
-                 image: Box<Iterator<Item = Colorf> + 'a>,
+                 image: Box<dyn Iterator<Item = Colorf> + 'a>,
                  width: usize,
                  map: &'a ColorMap,
-                 colorspace: &'a ColorSpace)
-                 -> Box<Iterator<Item = usize> + 'a>;
+                 colorspace: &'a dyn ColorSpace)
+                 -> Box<dyn Iterator<Item = usize> + 'a>;
 }
 
 /// A Ditherer that simply remaps each pixel to the nearest palette index without any actual
@@ -22,11 +22,11 @@ pub trait Ditherer {
 pub struct None;
 impl Ditherer for None {
     fn remap<'a>(&'a self,
-                 image: Box<Iterator<Item = Colorf> + 'a>,
+                 image: Box<dyn Iterator<Item = Colorf> + 'a>,
                  _: usize,
                  map: &'a ColorMap,
-                 _: &'a ColorSpace)
-                 -> Box<Iterator<Item = usize> + 'a> {
+                 _: &'a dyn ColorSpace)
+                 -> Box<dyn Iterator<Item = usize> + 'a> {
         Box::new(image.map(move |c| map.find_nearest(c)))
     }
 }
@@ -43,11 +43,11 @@ pub struct Ordered;
 const DITHER_MATRIX: [f64; 4] = [-0.375, 0.125, 0.375, -0.125];
 impl Ditherer for Ordered {
     fn remap<'a>(&'a self,
-                 image: Box<Iterator<Item = Colorf> + 'a>,
+                 image: Box<dyn Iterator<Item = Colorf> + 'a>,
                  width: usize,
                  map: &'a ColorMap,
-                 _: &'a ColorSpace)
-                 -> Box<Iterator<Item = usize> + 'a> {
+                 _: &'a dyn ColorSpace)
+                 -> Box<dyn Iterator<Item = usize> + 'a> {
         Box::new(image.enumerate()
             .map(move |(i, color)| {
                 let x = i % width;
@@ -82,11 +82,11 @@ impl FloydSteinberg {
 }
 impl Ditherer for FloydSteinberg {
     fn remap<'a>(&'a self,
-                 image: Box<Iterator<Item = Colorf> + 'a>,
+                 image: Box<dyn Iterator<Item = Colorf> + 'a>,
                  width: usize,
                  map: &'a ColorMap,
-                 colorspace: &'a ColorSpace)
-                 -> Box<Iterator<Item = usize> + 'a> {
+                 colorspace: &'a dyn ColorSpace)
+                 -> Box<dyn Iterator<Item = usize> + 'a> {
         let mut errors: Vec<Colorf> = (0..width * 2).map(|_| Colorf::zero()).collect();
         Box::new(image.enumerate()
             .map(move |(i, c)| {

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -50,7 +50,7 @@ impl Histogram {
     /// Converts the rgba8 `Histogram` to a Vec of `ColorCount` in quantization color space.
     ///
     /// Mostly used internally.
-    pub fn to_color_counts(&self, colorspace: &ColorSpace) -> Vec<ColorCount> {
+    pub fn to_color_counts(&self, colorspace: &dyn ColorSpace) -> Vec<ColorCount> {
         self.data
             .iter()
             .map(|(color, count)| {
@@ -63,7 +63,7 @@ impl Histogram {
     }
 
     /// Returns an iterator over the histogram data.
-    pub fn iter<'a>(&'a self) -> Box<Iterator<Item = (&Color, &usize)> + 'a> {
+    pub fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&Color, &usize)> + 'a> {
         Box::new(self.data.iter())
     }
 }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -24,7 +24,7 @@ pub trait Optimizer {
     ///   &histogram, 16);
     /// ```
     fn optimize_palette(&self,
-                        colorspace: &ColorSpace,
+                        colorspace: &dyn ColorSpace,
                         palette: &[Color],
                         histogram: &Histogram,
                         num_iterations: usize)

--- a/src/quantizer.rs
+++ b/src/quantizer.rs
@@ -208,7 +208,7 @@ impl Quantizer {
     /// }
     /// let palette = quantizer.colors(&colorspace);
     /// ```
-    pub fn optimize(self, optimizer: &Optimizer, num_iterations: usize) -> Quantizer {
+    pub fn optimize(self, optimizer: &dyn Optimizer, num_iterations: usize) -> Quantizer {
         if optimizer.is_noop() {
             return self;
         }

--- a/src/remapper.rs
+++ b/src/remapper.rs
@@ -70,9 +70,9 @@ impl<'a, T: ColorSpace, D: Ditherer + ?Sized> Remapper<'a, T, D> {
 
     /// Remap and dither a `Box<Iterator<Item = Color>>` to a `Box<Iterator<Item = u8>>`.
     pub fn remap_iter<'b>(&'b self,
-                          image: Box<Iterator<Item = Color> + 'b>,
+                          image: Box<dyn Iterator<Item = Color> + 'b>,
                           width: usize)
-                          -> Box<Iterator<Item = u8> + 'b> {
+                          -> Box<dyn Iterator<Item = u8> + 'b> {
         assert!(self.map.num_colors() <= 256);
         Box::new(self.ditherer
             .remap(Box::new(image.map(move |c| self.colorspace.to_float(c))),
@@ -84,9 +84,9 @@ impl<'a, T: ColorSpace, D: Ditherer + ?Sized> Remapper<'a, T, D> {
 
     /// Remap and dither a `Box<Iterator<Item = Color>>` to a `Box<Iterator<Item = usize>>`.
     pub fn remap_iter_usize<'b>(&'b self,
-                                image: Box<Iterator<Item = Color> + 'b>,
+                                image: Box<dyn Iterator<Item = Color> + 'b>,
                                 width: usize)
-                                -> Box<Iterator<Item = usize> + 'b> {
+                                -> Box<dyn Iterator<Item = usize> + 'b> {
         assert!(self.map.num_colors() <= 256);
         self.ditherer
             .remap(Box::new(image.map(move |c| self.colorspace.to_float(c))),


### PR DESCRIPTION
First of all, thanks for this library: I didn't really need it for anything, but I tried it for fun and it works like a charm.
The compiler, though, complains with warnings about how the trait are declared.
As said in the [official docs](https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html)

> The use of the dyn keyword to identify [trait objects](https://doc.rust-lang.org/book/ch17-02-trait-objects.html) will be mandatory in Rust 2021.

So I updated all the files involved. Moreover, I updated the examples with actually working suggestions.
As you can see, those are humble editings and don't mess with the actual code in any way.